### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,8 @@ jobs:
 
   create-release:
     name: 🎉 Create GitHub Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [validate-release, run-tests, build-artifacts, generate-changelog]
     


### PR DESCRIPTION
Potential fix for [https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/23](https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/23)

The best way to fix this issue is to explicitly declare a `permissions` block for the `create-release` job. Since this job only needs to create a release and upload release assets via the GitHub API, the minimal necessary permission is `contents: write`. You should add a `permissions:` section under `create-release:` (right below line 214, or above `runs-on:` on line 215) as follows:

```yaml
permissions:
  contents: write
```

This change narrows the GITHUB_TOKEN's power, reducing risk without impacting the release workflow. Only the `create-release` job needs this change; other jobs should continue using their existing permissions blocks (for example, `post-release` already has `contents: read`).  
No additional methods/imports are necessary, as this is a YAML configuration for a GitHub Actions workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
