### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -118,6 +118,8 @@ jobs:
   # Separate job for license compliance
   license-check:
     name: 📜 License Compliance Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - name: 📥 Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/22](https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/22)

To address the issue, add a `permissions` block to the `license-check` job in `.github/workflows/dependency-scan.yml` and set its permissions as restrictive as possible. For jobs that do not require any write access to the repository (e.g., only reading repository files, uploading Actions artifacts), the minimal permissions should be `contents: read`. Insert the following under `license-check:` before `runs-on`. No other imports or methods are required. Edit only within the file and lines provided.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
