### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🛡️ Dependency Security Scan
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/21](https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/21)

To fix the problem, add a `permissions:` block specifying the least privileges needed by the workflow. The best place to do this is at the top-level (after the `name` but before `on:` or `jobs:`), so all jobs inherit this unless overridden. For these jobs, the minimum required permission is `contents: read`, which allows actions to read repository contents without allowing writes. If in future a job requires broader permissions, you can override it at the job level, but defaulting to read-only is recommended.

Edit the `.github/workflows/dependency-scan.yml` file, and insert the following block after the `name:`:  
```yaml
permissions:
  contents: read
```
This requires no imports or other method changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
