### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
     # Run weekly quality checks
     - cron: '0 2 * * 1'
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.11'
   NODE_VERSION: '18'


### PR DESCRIPTION
Potential fix for [https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/19](https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/19)

To fix this issue, we should add an explicit `permissions:` block specifying the minimal required permissions for the affected jobs. Since the workflow does not perform any write operations (no pushes, merges, or use of GitHub APIs to alter repo state), it is best to set `permissions: contents: read` at the workflow level, which applies to all jobs unless overridden. If some jobs need additional permissions (for instance, uploading SARIF files requires `security-events: write`), those can be specified in the relevant jobs; otherwise, overall default can be `contents: read`. This change should be made at the top level of the workflow YAML file (after the `name:` field and before or right after `on:`), without altering any functional aspects of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
