### PR TITLE
Potential fix for code scanning alert no. 1392: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🔐 Professional CodeQL Python Security Analysis
 
 "on":


### PR DESCRIPTION
Potential fix for [https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/1392](https://github.com/JLWard429/ai-script-inventory-/security/code-scanning/1392)

The best way to fix the problem is to add an explicit `permissions` block to define the minimal GITHUB_TOKEN access required by the workflow or the specific jobs. Since all tasks here appear to only require reading repository contents and uploading an artifact (which does not require additional token permissions), a safe baseline is `contents: read` at the workflow level. For most CodeQL scanning workflows, this suffices. Add the following block at the root of the YAML file below the `name` field and above `on:` to ensure it applies to all jobs, or you may specify it under each job as needed. This change does not alter any workflow logic—just the permissions of the auto-generated GITHUB_TOKEN.

To implement:  
- Insert a `permissions:` block near the top of `.github/workflows/codeql.yml` (after `name: ...`).
- Set:  
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
